### PR TITLE
bugfix for sampleSize

### DIFF
--- a/src/main/java/org/opengis/cite/iso19142/util/DataSampler.java
+++ b/src/main/java/org/opengis/cite/iso19142/util/DataSampler.java
@@ -110,6 +110,7 @@ public class DataSampler {
         }
         int sampleSize = result.size();
         Random random = new Random();
+        numId = numId > sampleSize ? sampleSize : numId;
         while (idSet.size() < numId) {
             int randomInt = random.nextInt(sampleSize);
             idSet.add(result.itemAt(randomInt).getStringValue());


### PR DESCRIPTION
hi,

we have discovered a bug in the wfs20 conformance test suite for the following case:

- DataSampler#selectRandomFeatureIdentifiers has a bug if the method is called with a numId > than the existing feature available (i.e. which were retrieved somewhere at the beginning of the test and stored in the tmp directory) the WHILE loop never returns.

could you pls let us know how long it take to release a new version on mavern central as soon as you have accepted our pull request.

cheers,
michael clay and michael waltl