### PR TITLE
Fixed handling of decimal data type

### DIFF
--- a/src/main/java/org/opengis/cite/iso19142/basic/filter/ComparisonOperatorTests.java
+++ b/src/main/java/org/opengis/cite/iso19142/basic/filter/ComparisonOperatorTests.java
@@ -1,5 +1,7 @@
 package org.opengis.cite.iso19142.basic.filter;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
@@ -8,11 +10,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
-import java.util.logging.Level;
 import java.util.Set;
+import java.util.logging.Level;
 
 import javax.xml.XMLConstants;
 import javax.xml.bind.DatatypeConverter;
@@ -70,7 +73,9 @@ import com.sun.jersey.api.client.ClientResponse;
  * </ul>
  */
 public class ComparisonOperatorTests extends QueryFilterFixture {
-
+    
+    private static final DecimalFormat FORMATTER = new DecimalFormat("##0.######", DecimalFormatSymbols.getInstance( Locale.ENGLISH ));
+    
 	private static String MATCH_ALL = "All";
 	private static String MATCH_ANY = "Any";
 
@@ -618,7 +623,7 @@ public class ComparisonOperatorTests extends QueryFilterFixture {
 				values[i] = dtFactory.newXMLGregorianCalendar(gCal).normalize()
 						.toString();
 			} else {
-				values[i] = objValues[i].toString();
+				values[i] = FORMATTER.format( (Double )objValues[i] );
 			}
 		}
 	}

--- a/src/test/java/org/opengis/cite/iso19142/basic/filter/VerifyComparisonOperatorTests.java
+++ b/src/test/java/org/opengis/cite/iso19142/basic/filter/VerifyComparisonOperatorTests.java
@@ -133,6 +133,14 @@ public class VerifyComparisonOperatorTests {
     }
 
     @Test
+    public void sortNumericValuesWithENotation() {
+        String[] values = new String[] { "0.8", "1.20528E9", "1.20528E10" };
+        ComparisonOperatorTests iut = new ComparisonOperatorTests();
+        iut.sortValues(values);
+        assertEquals("Unexpected values[1].", "1205280000", values[1]);
+    }
+    
+    @Test
     public void sortDateTimeValues() {
         String[] values = new String[] { "2012-12-12T17:00:00+04:00",
                 "2012-12-12T10:00:00-08:00", "2012-12-12T17:00:00Z" };


### PR DESCRIPTION
Previously, the test suite did not handle the decimal data type correct and used the e notation (e.g. "1.20528E9") for requests (which is not conform to XML).

This fix adds a formatter for decimal values to prevent the e notation in requests.