### PR TITLE
#74 Comparison test fails to build proper xpath validation expression

### DIFF
--- a/src/main/java/org/opengis/cite/iso19142/util/AppSchemaUtils.java
+++ b/src/main/java/org/opengis/cite/iso19142/util/AppSchemaUtils.java
@@ -243,6 +243,18 @@ public class AppSchemaUtils {
             datatype = new QName(XMLConstants.W3C_XML_SCHEMA_NS_URI, "decimal");
             break;
         case XSConstants.INTEGER_DT:
+        case XSConstants.BYTE_DT:
+        case XSConstants.UNSIGNEDBYTE_DT:
+        case XSConstants.INT_DT:
+        case XSConstants.UNSIGNEDINT_DT:
+        case XSConstants.LONG_DT:
+        case XSConstants.UNSIGNEDLONG_DT:
+        case XSConstants.NEGATIVEINTEGER_DT:
+        case XSConstants.POSITIVEINTEGER_DT:
+        case XSConstants.NONNEGATIVEINTEGER_DT:
+        case XSConstants.NONPOSITIVEINTEGER_DT:
+        case XSConstants.SHORT_DT:
+        case XSConstants.UNSIGNEDSHORT_DT:
             datatype = new QName(XMLConstants.W3C_XML_SCHEMA_NS_URI, "integer");
             break;
         case XSConstants.STRING_DT:

--- a/src/test/java/org/opengis/cite/iso19142/transaction/VerifyUpdate.java
+++ b/src/test/java/org/opengis/cite/iso19142/transaction/VerifyUpdate.java
@@ -89,7 +89,7 @@ public class VerifyUpdate {
         List<String> propValues = new ArrayList<String>();
         propValues.add("49.25");
         Update iut = new Update();
-        String newVal = iut.newPropertyValue(simpleProps.get(simpleProps.size() - 1), propValues);
+        String newVal = iut.newPropertyValue(simpleProps.get(5), propValues);
         assertEquals(4.925, Double.parseDouble(newVal), 0.0001);
     }
 
@@ -100,7 +100,7 @@ public class VerifyUpdate {
         List<String> propValues = new ArrayList<String>();
         propValues.add("2010-01-01");
         Update iut = new Update();
-        String newVal = iut.newPropertyValue(simpleProps.get(simpleProps.size() - 2), propValues);
+        String newVal = iut.newPropertyValue(simpleProps.get(4), propValues);
         assertEquals(LocalDate.now(ZoneId.of("Z")), LocalDate.parse(newVal));
     }
 }

--- a/src/test/java/org/opengis/cite/iso19142/util/VerifyAppSchemaUtils.java
+++ b/src/test/java/org/opengis/cite/iso19142/util/VerifyAppSchemaUtils.java
@@ -1,6 +1,9 @@
 package org.opengis.cite.iso19142.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -57,7 +60,7 @@ public class VerifyAppSchemaUtils {
         XSTypeDefinition xsdDoubleType = model.getTypeDefinition("decimal", XMLConstants.W3C_XML_SCHEMA_NS_URI);
         List<XSElementDeclaration> props = AppSchemaUtils.getFeaturePropertiesByType(model, featureTypeName,
                 xsdDoubleType);
-        assertEquals("Unexpected number of xsd:decimal properties.", 2, props.size());
+        assertEquals("Unexpected number of xsd:decimal properties.", 14, props.size());
     }
 
     @Test
@@ -159,5 +162,32 @@ public class VerifyAppSchemaUtils {
         XSElementDeclaration value = AppSchemaUtils.getComplexPropertyValue(multiGeomProperty);
         assertEquals("Unexpected namespace", GML32.NS_NAME, value.getNamespace());
         assertEquals("Unexpected name.", "AbstractGeometricAggregate", value.getName());
+    }
+
+    @Test
+    public void findSimpleProperties_integerType() {
+        String[] integerProperties = {"byteProperty", "intProperty2", "longProperty",
+                "negativeIntegerProperty", "nonNegativeIntegerProperty",
+                "nonPositiveIntegerProperty", "positiveIntegerProperty", "shortProperty",
+                "unsignedLongProperty", "unsignedIntProperty", "unsingedShortProperty",
+                "unsignedByteProperty"};
+        for (String property : integerProperties) {
+            XSElementDeclaration declaration = getPropertyByLocalName(property);
+            assertNotNull("Could not find property " + property, declaration);
+            QName qName = AppSchemaUtils.getBuiltInDatatype(declaration);
+            assertEquals("integer", qName.getLocalPart());
+        }
+    }
+
+    private XSElementDeclaration getPropertyByLocalName(String name) {
+        QName featureTypeName = new QName(EX_NS, "SimpleFeature");
+        List<XSElementDeclaration> simpleProps = AppSchemaUtils.getSimpleFeatureProperties(model, featureTypeName);
+        for (XSElementDeclaration simpleProp : simpleProps) {
+            if (name.equals(simpleProp.getName())) {
+                return simpleProp;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/test/resources/xsd/simple.xsd
+++ b/src/test/resources/xsd/simple.xsd
@@ -50,6 +50,18 @@
 							<xsd:appinfo xsi:type="tns:SimpleFeature" />
 						</xsd:annotation>
 					</xsd:element>
+					<xsd:element name="byteProperty" type="xsd:byte" />
+					<xsd:element name="longProperty" type="xsd:long" />
+					<xsd:element name="negativeIntegerProperty" type="xsd:negativeInteger" />
+					<xsd:element name="nonNegativeIntegerProperty" type="xsd:nonNegativeInteger" />
+					<xsd:element name="nonPositiveIntegerProperty" type="xsd:nonPositiveInteger" />
+					<xsd:element name="positiveIntegerProperty" type="xsd:positiveInteger" />
+					<xsd:element name="shortProperty" type="xsd:short" />
+					<xsd:element name="unsignedIntProperty" type="xsd:unsignedInt" />
+					<xsd:element name="unsignedLongProperty" type="xsd:unsignedLong" />
+					<xsd:element name="unsingedShortProperty" type="xsd:unsignedShort" />
+					<xsd:element name="unsignedByteProperty" type="xsd:unsignedByte" />
+					<xsd:element name="intProperty2" type="xsd:int" />
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>


### PR DESCRIPTION
This seems to fix the xpath building issues on "xs:int", I've added the other restrictions for completeness.
The tests are actually somewhat random (event before the fix, sometimes it failed, sometimes it did not, depending on which property got picked for comparison tests), so I cannot be 100% sure the fix actually works, but never failed in a number of runs, so it is hopefully ok.

Had to adjust a bit a few tests assuming a certain number of properties, in a certain order, in the reference simple feature schema, to deal with the extra attributes I've added.

Fixes #74.