### PR TITLE
Correct an issue with conflict in filename normalization causing crash

### DIFF
--- a/src/main/java/org/opengis/cite/iso19142/TestNGController.java
+++ b/src/main/java/org/opengis/cite/iso19142/TestNGController.java
@@ -111,7 +111,7 @@ public class TestNGController implements TestSuiteController {
         if (null == outputDir || outputDir.isEmpty()) {
             resultsDir = new File(FilenameUtils.normalize(System.getProperty("user.home")));
         } else if (outputDir.startsWith("file:")) {
-            resultsDir = new File(URI.create(FilenameUtils.normalize(outputDir)));
+            resultsDir = new File(FilenameUtils.normalize(outputDir));
         } else {
             resultsDir = new File(outputDir);
         }


### PR DESCRIPTION
Correction for an issue with conflict between FilenameUtils.normalize and URI.create.

Here is the error report when it crashes:

Fatal Error: Error in call to extension function {public org.opengis.cite.iso191
42.TestNGController(java.lang.String)}: Exception in extension function: java.la
ng.IllegalArgumentException: Illegal character in opaque part at index 5: file:\
C:\TE_BASE\users\username\s0024; SystemID: file:/C:/TE_BASE/work/_TE_BASE_scripts
_wfs_2.0.0_ctl_wfs-suite.ctl/tns$run-ets-wfs20.fn; Line#: 47; Column#: -1
Fatal Error: Error in call to extension function {public java.lang.Object com.oc
camlab.te.TECore.callFunction(net.sf.saxon.expr.XPathContext,java.lang.String,ja
va.lang.String,net.sf.saxon.om.NodeInfo) throws java.lang.Exception}: Exception
in extension function net.sf.saxon.s9api.SaxonApiException: Error in call to ext
ension function {public org.opengis.cite.iso19142.TestNGController(java.lang.Str
ing)}: Exception in extension function: java.lang.IllegalArgumentException: Ille
gal character in opaque part at index 5: file:\C:\TE_BASE\users\ username \s0024; S
ystemID: file:/C:/TE_BASE/work/_TE_BASE_scripts_wfs_2.0.0_ctl_wfs-suite.ctl/tns$
Main.test; Line#: 141; Column#: -1
Sep 10, 2018 12:02:38 PM com.occamlab.te.TECore executeTest
SEVERE: Error in call to extension function {public java.lang.Object com.occamla
b.te.TECore.callFunction(net.sf.saxon.expr.XPathContext,java.lang.String,java.la
ng.String,net.sf.saxon.om.NodeInfo) throws java.lang.Exception}: Exception in ex
tension function net.sf.saxon.s9api.SaxonApiException: Error in call to extensio
n function {public org.opengis.cite.iso19142.TestNGController(java.lang.String)}
: Exception in extension function: java.lang.IllegalArgumentException: Illegal c
haracter in opaque part at index 5: file:\C:\TE_BASE\users\ username \s0024
   Test tns:Main Failed
                        See the detail test Report 
C:\TE_BASE\users\ username /s0024/log.xml
                        See the detail error Report 
C:\TE_BASE\users\ username/s0024/error_log/log.txt
Suite tns:ets-wfs20-1.31-SNAPSHOT Failed

-----------------------------

Description of the problem:

The issue is due to line 114 in TestNGController.java, see the following block of code:
        if (null == outputDir || outputDir.isEmpty()) {
            resultsDir = new File(FilenameUtils.normalize(System.getProperty("user.home")));
        } else if (outputDir.startsWith("file:")) {
            resultsDir = new File(URI.create(FilenameUtils.normalize(outputDir)));   // <--- Line 114
        } else {
            resultsDir = new File(outputDir);
        }

The call to "FilenameUtils.normalize" here is being performed within the block "} else if (outputDir.startsWith("file:")) {"

The value of outputDir may be starting out as something like:
"file:/C:/TE_BASE/users/ username /s0014" but after FilenameUtils.normalize, we end up with:
"file:\\C:\\TE_BASE\\users\\username\\s0014",
And this 'normalized' path, if sent to URI.create will result in the failure shown above. 
The URI.create and FilenameUtils.normalize cannot be used together.

There appears to be no reason to create a URI when FilenameUtils will perform the necessary steps to create a viable filename.  Removing the call to URI.create


