### PR TITLE
Added skip exception in joinWithIntersects test when geometry type is not supported.

### DIFF
--- a/src/main/java/org/opengis/cite/iso19142/joins/SpatialJoinTests.java
+++ b/src/main/java/org/opengis/cite/iso19142/joins/SpatialJoinTests.java
@@ -215,7 +215,7 @@ public class SpatialJoinTests extends QueryFilterFixture {
             joinProperties.add(new FeatureProperty(entryPointProps.getKey(), entryPointProps.getValue().get(0)));         
         }
         else{
-           Assert.fail("This test has triggered an unexpected Spatial Join condition. The Spatial Join test will need to be applied manually.");       
+           throw new SkipException("This test has triggered an unexpected Spatial Join condition. The Spatial Join test will need to be applied manually.");       
         } 
         JoinQueryUtils.appendSpatialJoinQuery(this.reqEntity, "Intersects", joinProperties);
         ClientResponse rsp = wfsClient.submitRequest(this.reqEntity, ProtocolBinding.ANY);


### PR DESCRIPTION
Fixed #175.