### PR TITLE
Remove final modifier to fix aio jar

### DIFF
--- a/src/main/java/org/opengis/cite/iso19142/CommandLineArguments.java
+++ b/src/main/java/org/opengis/cite/iso19142/CommandLineArguments.java
@@ -29,7 +29,7 @@ import java.util.List;
 public class CommandLineArguments {
 
     @Parameter(description = "Properties file")
-    private final List<String> xmlProps;
+    private List<String> xmlProps;
 
     @Parameter(names = { "-o", "--outputDir" }, description = "Output directory")
     private String outputDir;

--- a/src/main/resources/test-run-props.xml
+++ b/src/main/resources/test-run-props.xml
@@ -2,6 +2,6 @@
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties version="1.0">
     <comment>WFS 2.0 reference implementation</comment>
-    <entry key="wfs">http://cite.deegree.org/deegree-webservices-3.4.16/services/wfs200?request=GetCapabilities&amp;service=WFS&amp;version=2.0.0</entry>
+    <entry key="wfs">http://cite.deegree.org/deegree-webservices-3.5.6/services/wfs200?request=GetCapabilities&amp;service=WFS&amp;version=2.0.0</entry>
     <entry key="acceptMediaType">application/zip</entry>
 </properties>


### PR DESCRIPTION
This error is fixed:
```
stenger@elsbeere:~/git/ets-wfs20/target$ java -jar ets-wfs20-1.41-SNAPSHOT-aio.jar ~/git/ets-wfs20/src/main/resources/test-run-props.xml 
Exception in thread "main" com.beust.jcommander.ParameterException: Cannot use final field org.opengis.cite.iso19142.CommandLineArguments#xmlProps as a parameter; compile-time constant inlining may hide new values written to it.
	at com.beust.jcommander.Parameterized.setFieldAccessible(Parameterized.java:251)
	at com.beust.jcommander.Parameterized.<init>(Parameterized.java:33)
	at com.beust.jcommander.Parameterized.parseArg(Parameterized.java:110)
	at com.beust.jcommander.parser.DefaultParameterizedParser.parseArg(DefaultParameterizedParser.java:23)
	at com.beust.jcommander.JCommander.addDescription(JCommander.java:608)
	at com.beust.jcommander.JCommander.createDescriptions(JCommander.java:601)
	at com.beust.jcommander.JCommander.<init>(JCommander.java:252)
	at com.beust.jcommander.JCommander.<init>(JCommander.java:238)
	at com.beust.jcommander.JCommander.<init>(JCommander.java:230)
	at org.opengis.cite.iso19142.TestNGController.main(TestNGController.java:64)
```