### PR TITLE
Upgrade ets-common and maven-fluido-skin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.opengis.cite</groupId>
     <artifactId>ets-common</artifactId>
-    <version>13</version>
+    <version>14</version>
   </parent>
   <artifactId>ets-wfs20</artifactId>
   <version>1.44-SNAPSHOT</version>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -7,7 +7,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.5</version>
+    <version>2.0.1</version>
   </skin>
   <custom>
     <fluidoSkin>

--- a/src/site/xhtml/index.xhtml.vm
+++ b/src/site/xhtml/index.xhtml.vm
@@ -276,7 +276,7 @@ dt {
       <li style="list-style:square">Integrated development environment (IDE): The main Java class is <code>
 	  org.opengis.cite.iso19142.TestNGController</code>.</li>
       <li style="list-style:square">REST API: Submit a request that includes the necessary 
-      arguments to the test run controller (/rest/suites/${ets-code}/${project.version}/run).</li>
+      arguments to the test run controller (/rest/suites/${maven.site.properties['ets-code']}/${project.version}/run).</li>
       <li style="list-style:square">TEAM Engine: Run the CTL script located in the <code>/src/main/ctl/</code> 
 	  directory.</li>
     </ul>

--- a/src/site/xhtml/index.xhtml.vm
+++ b/src/site/xhtml/index.xhtml.vm
@@ -276,7 +276,7 @@ dt {
       <li style="list-style:square">Integrated development environment (IDE): The main Java class is <code>
 	  org.opengis.cite.iso19142.TestNGController</code>.</li>
       <li style="list-style:square">REST API: Submit a request that includes the necessary 
-      arguments to the test run controller (/rest/suites/${maven.site.properties['ets-code']}/${project.version}/run).</li>
+      arguments to the test run controller (/rest/suites/wfs20/run).</li>
       <li style="list-style:square">TEAM Engine: Run the CTL script located in the <code>/src/main/ctl/</code> 
 	  directory.</li>
     </ul>


### PR DESCRIPTION
Upgrading `maven-fluido-skin` to version 2.0.1 (site.xml) while using `ets-common` version 13 (pom.xml) caused the maven build to fail. The issue arises because `Doxia Sitetools` requires version 2.0.0, but `ets-common` version 13 provides only 1.11.1. It was fixed by upgrading to  `ets-common` version 14 , since it uses `Doxia Sitetools` version 2.0.0.